### PR TITLE
Add EDIM to the list of packages being tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
     - PKG_NAME=deepthought
     - PKG_NAME=design
     - PKG_NAME=digraphs
+#    - PKG_NAME=edim # currently broken on master
     - PKG_NAME=example
     - PKG_NAME=factint
     - PKG_NAME=fga


### PR DESCRIPTION
For some reason EDIM was tested neither in staging nor in the working
package tests. It currently won't pass tests due to a regression, and
I didn't notice because it wasn't present in these docker tests.

I submitted a fix to the EDIM package, see <https://github.com/frankluebeck/EDIM/pull/10>

See also https://github.com/gap-infra/gap-docker-pkg-tests-master-staging/pull/4

UPDATE: Ah, I see now why EDIM is not there: Because while a test file was added in February 2018, no release of EDIM was made since then by Frank... I'll try to get him to merge my fix and then release one quickly. Let's keep this PR around till then, as a reminder?